### PR TITLE
Enable corepack during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:20-alpine as builder
 WORKDIR /src
 
 COPY . /src/
-RUN yarn install
+RUN corepack enable && yarn install
 ENV NODE_OPTIONS=--max_old_space_size=4096
 RUN yarn build
 


### PR DESCRIPTION
### Description

Adds `corepack enable` to the docker setup steps.

This fixes the following error when running e.g. `docker build -t variance:latest .`:

```
 => ERROR [builder 4/5] RUN yarn install                                                                                                                                                                                                       0.3s
------
 > [builder 4/5] RUN yarn install:
0.300 error This project's package.json defines "packageManager": "yarn@4.4.1". However the current global version of Yarn is 1.22.22.
0.300
0.300 Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
0.300 Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
Dockerfile:7
--------------------
   5 |
   6 |     COPY . /src/
   7 | >>> RUN yarn install
   8 |     ENV NODE_OPTIONS=--max_old_space_size=4096
   9 |     RUN yarn build
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn install" did not complete successfully: exit code: 1
```

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
