### PR TITLE
Include custom emoji in emoji search

### DIFF
--- a/src/app/organisms/emoji-board/EmojiBoard.tsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.tsx
@@ -216,8 +216,13 @@ function EmojiBoard({
   function handleSearchChange() {
     const term = searchRef.current.value;
 
+    // availableEmojis is an array of image packs. We need to extract the
+    // cumulative set of emoticons in each pack. Flatmap is our friend.
     const emoji = availableEmojis.flatMap(({ emoticons }) => emoticons);
+
+    // Add in the standard emoji set
     emoji.push(...emojis);
+
     asyncSearch.setup(emoji, { keys: ['shortcode'], isContain: true, limit: 40 });
 
     asyncSearch.search(term);

--- a/src/app/organisms/emoji-board/EmojiBoard.tsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.tsx
@@ -217,6 +217,7 @@ function EmojiBoard({
     const term = searchRef.current.value;
 
     const emoji = availableEmojis.flatMap(({ emoticons }) => emoticons);
+    emoji.push(...emojis);
     asyncSearch.setup(emoji, { keys: ['shortcode'], isContain: true, limit: 40 });
 
     asyncSearch.search(term);

--- a/src/app/organisms/emoji-board/available-emoji.ts
+++ b/src/app/organisms/emoji-board/available-emoji.ts
@@ -1,0 +1,51 @@
+import initMatrix from '../../../client/initMatrix';
+import cons from '../../../client/state/cons';
+import navigation from '../../../client/state/navigation';
+import { getRelevantPacks } from './custom-emoji';
+
+interface Emoji {
+  shortcode: string;
+  src: string | HTMLElement;
+  unicode: string;
+}
+
+interface ImagePack {
+  id: string;
+  content: {
+    images: object;
+  };
+  packIndex: number;
+  emoticons: Emoji[];
+}
+
+const availableEmoji: ImagePack[] = [];
+
+navigation.on(cons.events.navigation.ROOM_SELECTED, (roomId: string) => {
+  if (!roomId) {
+    availableEmoji.length = 0;
+    return;
+  }
+
+  const client = initMatrix.matrixClient;
+  const room = client.getRoom(roomId);
+
+  if (room) {
+    const parentRoomIds: Set<string> = initMatrix.roomList.getAllParentSpaces(room.roomId);
+    const parentRooms = Array.from(parentRoomIds).map((id) => client.getRoom(id));
+
+    const packs: ImagePack[] = getRelevantPacks(room.client, [room, ...parentRooms]).filter(
+      (pack) => pack.getEmojis().length > 0,
+    );
+
+    for (let i = 0; i < packs.length; i += 1) {
+      packs[i].packIndex = i;
+    }
+
+    availableEmoji.length = 0;
+    availableEmoji.push(...packs);
+  } else {
+    availableEmoji.length = 0;
+  }
+});
+
+export default availableEmoji;


### PR DESCRIPTION
<!-- Please read https://github.com/mat-1/variance/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

This PR makes a small handful of changes:
- Adds an `available-emoji` module. This module subscribes to the navigation `ROOM_SELECTED` events and gets the list of emoji and packs that are relevant for that room. The module exports an array of image packs. The array is constant; its contents are mutated over time. That way consumers of this module can simply reference the module export and will always have the correct list.
  - Why: Previously this list of emoji was only calculated in the EmojiBoard `ROOM_SELECTED` event handler. The initial `ROOM_SELECTED` event is emitted before the EmojiBoard subscribes to it, which means custom emoji were missing from the EmojiBoard at first if Variance loads to a room. The only way to get custom emoji to show up in the EmojiBoard was by changing rooms to trigger the event handler.
  - Rather than duplicate the event logic, I opted to just move it to one place and have the event subscription happen at module load time rather than as part of component setup. That way it is registered before the first event is fired.
- Removes the `ROOM_SELECTED `event handler from the EmojiBoard component.
  - Why: See above.
- Updates the `handleSearchChange` method of the event handler to reset the AsyncSearch to use the current list of available emoji instead of whatever emoji were available at load-time.
  - Previously, the list of available for searching was just those defined in `emoji.ts` (from emojibase)

The result of all this is twofold:
- On initial load, the emoji picker shows standard and custom emoji
- The emoji picker search bar can search for custom emoji as well

Apologies for not discussing this with @mat-1 first! I've got a friend group that recently started using Matrix and Variance has been our favorite client so far. One thing we were missing was being able to search our custom emoji (because we have A LOT), and since I'd already forked the code, I decided to just jump in and try to add that behavior.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
