### PR TITLE
Don't hide message context menu when message hover is removed

### DIFF
--- a/src/app/atoms/context-menu/ContextMenu.tsx
+++ b/src/app/atoms/context-menu/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import './ContextMenu.scss';
 
@@ -22,9 +22,40 @@ function ContextMenu({
   render: (toggleMenu: () => void) => React.ReactNode;
   afterToggle?: (isVisible: boolean) => void;
 }) {
+  // Initialize with an empty, disconnected element. This is for type-safety.
+  const ref = useRef(document.createElement('div'));
+
   const [isVisible, setVisibility] = useState(false);
-  const showMenu = () => setVisibility(true);
-  const hideMenu = () => setVisibility(false);
+
+  // If this menu is attached to a message, add a class to the message to
+  // indicate that the menu is open. This is used to keep the menu visible if
+  // the user moves hover away from the message.
+  const showMenu = () => {
+    if (ref) {
+      const parent: Element = ref.current;
+      if (parent?.closest) {
+        const message = parent.closest('.message');
+        if (message) {
+          message.classList.add('message--menu-visible');
+        }
+      }
+    }
+    return setVisibility(true);
+  };
+
+  const hideMenu = () => {
+    // If this menu is attached to a message, remove the menu class.
+    if (ref) {
+      const parent: Element = ref.current;
+      if (parent?.closest) {
+        const message = parent.closest('.message');
+        if (message) {
+          message.classList.remove('message--menu-visible');
+        }
+      }
+    }
+    return setVisibility(false);
+  };
 
   useEffect(() => {
     if (afterToggle) afterToggle(isVisible);
@@ -35,6 +66,7 @@ function ContextMenu({
     <Tippy
       animation="scale-extreme"
       className="context-menu"
+      ref={ref}
       visible={isVisible}
       onClickOutside={hideMenu}
       content={

--- a/src/app/molecules/message/Message.scss
+++ b/src/app/molecules/message/Message.scss
@@ -9,7 +9,8 @@
   @include dir.side(padding, var(--sp-normal), var(--sp-extra-tight));
   display: flex;
 
-  &:hover {
+  &:hover,
+  &.message--menu-visible {
     background-color: var(--bg-surface-hover);
     & .message__options {
       display: flex;


### PR DESCRIPTION
### Description

This PR adds a React `ref` to the ContextMenu object. When the menu is shown or hidden, the ref's ancestral tree is queried for any elements with the `message` class. If one is found, a `message--menu-visible` class is added or removed, as appropriate. The CSS is updated to extend the `.message:hover` selector to `.message:hover, .message.message--menu-visible`.

The result is that when the context menu is opened for a message, it stays opened even if the message loses hover. Opening the context menu on another message closes the first one and opens the second one. Clicking outside of the context menu also closes.

Fixes #9

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
